### PR TITLE
Refactor: Add defensive parseInt in A* traversability check

### DIFF
--- a/js/core/unit.js
+++ b/js/core/unit.js
@@ -159,33 +159,37 @@ class Unit {
                 }
 
                 if (needsNewPath && this.pathRequestCooldown <= 0) {
+                    const moveType = this.type.movementType || 'land';
+                    console.log(`Unit ${this.type.name} requesting path. MovementType: '${moveType}'`); // ADD THIS LOG (uncommented)
                     this.path = findPath(
                         { x: this.x, y: this.y },
                         { x: currentPrimaryDestination.x, y: currentPrimaryDestination.y },
                         gameContext,
-                        this.type.movementType || 'land'
+                        moveType
                     );
                     this.currentWaypointIndex = 0;
                     this.pathRequestCooldown = this.PATH_REQUEST_INTERVAL;
                     if (!this.path) {
                         if (gameContext.addEvent) gameContext.addEvent(gameContext, 'debug', `Path not found: ${this.type.name} to ${currentPrimaryDestination.type ? currentPrimaryDestination.type.name : 'point'}`, 0);
                         // console.log(`Unit ${this.type.name} (${this.team}) could not find path to ${currentPrimaryDestination.type ? currentPrimaryDestination.type.name : 'point'}.`);
-                        // Optional: Clear target if path fails, to prevent repeated attempts to a known unreachable spot.
-                        // this.target = null; this.patrolTarget = null;
                     } else {
                          if (gameContext.addEvent) gameContext.addEvent(gameContext, 'debug', `Path found for ${this.type.name} with ${this.path.length} waypoints.`, 0);
+                         console.log(`DEBUG: Unit ${this.type.name} new path found. Length: ${this.path.length}. Waypoints: ${JSON.stringify(this.path)}`); // JSON.stringify can be verbose
                     }
                 }
 
                 // PATH FOLLOWING
                 if (this.path && this.currentWaypointIndex < this.path.length) {
+                    console.log(`DEBUG: Unit ${this.type.name} (${this.team}, ID: ${this.id || 'N/A'}) at (${this.x.toFixed(1)}, ${this.y.toFixed(1)}). Path length: ${this.path.length}. Current WP Index: ${this.currentWaypointIndex}.`);
                     const waypoint = this.path[this.currentWaypointIndex];
                     const dx = waypoint.x - this.x;
                     const dy = waypoint.y - this.y;
                     const distanceToWaypoint = Math.sqrt(dx * dx + dy * dy);
-                    const WAYPOINT_REACH_THRESHOLD = TILE_SIZE * 0.5;
+                    const WAYPOINT_REACH_THRESHOLD = Math.max(this.type.size || 10, TILE_SIZE * 0.75);
+                    console.log(`DEBUG: Unit ${this.type.name} targeting WP ${this.currentWaypointIndex}: (${waypoint.x.toFixed(1)}, ${waypoint.y.toFixed(1)}). Dist: ${distanceToWaypoint.toFixed(1)}. Threshold: ${WAYPOINT_REACH_THRESHOLD.toFixed(1)}`);
 
                     if (distanceToWaypoint < WAYPOINT_REACH_THRESHOLD) {
+                        console.log(`DEBUG: Unit ${this.type.name} REACHED WP ${this.currentWaypointIndex}.`);
                         this.currentWaypointIndex++;
                         if (this.currentWaypointIndex >= this.path.length) { // Reached end of path
                             this.path = null;

--- a/js/pathfinding/astar.js
+++ b/js/pathfinding/astar.js
@@ -24,28 +24,48 @@ function calculateHeuristic(nodeA, nodeB) {
 }
 
 function isTraversable(gridX, gridY, gameContext, unitMovementType) {
-    const { terrain } = gameContext;
+    const { terrain } = gameContext; // gameConstants are imported at module level
+
+    console.log(`isTraversable CALLED: gridX=${gridX}, gridY=${gridY}, unitMovementType='${unitMovementType}'`);
 
     // Check bounds
     if (gridX < 0 || gridX >= GRID_SIZE || gridY < 0 || gridY >= GRID_SIZE) {
+        console.log(`isTraversable: Out of bounds.`);
         return false;
     }
-    if (!terrain[gridX] || terrain[gridX][gridY] === undefined) {
-        console.warn(`A* isTraversable: Terrain data missing at ${gridX},${gridY}`);
+    if (!terrain[gridX] || terrain[gridX][gridY] === undefined) { // This check might be problematic if terrain[gridX] itself is undefined
+        console.log(`isTraversable: Terrain data missing or undefined at [${gridX}][${gridY}].`);
         return false;
     }
 
-    const terrainType = terrain[gridX][gridY];
+    const terrainTypeAtNodeRaw = terrain[gridX][gridY];
+    const terrainTypeAtNode = parseInt(terrainTypeAtNodeRaw, 10);
+
+    console.log(`isTraversable: Node [${gridX},${gridY}] has RawType='${terrainTypeAtNodeRaw}' (type: ${typeof terrainTypeAtNodeRaw}), ParsedType=${terrainTypeAtNode} (type: ${typeof terrainTypeAtNode})`);
+    console.log(`isTraversable: Comparing against TERRAIN_TYPES: LAND=${TERRAIN_TYPES.LAND}, WATER=${TERRAIN_TYPES.WATER}, MOUNTAIN=${TERRAIN_TYPES.MOUNTAIN}`);
+
+    if (isNaN(terrainTypeAtNode)) {
+        console.log(`isTraversable: Parsed terrainType is NaN for raw value '${terrainTypeAtNodeRaw}'. Node [${gridX},${gridY}] considered not traversable.`);
+        return false;
+    }
 
     if (unitMovementType === 'land') {
-        return terrainType !== TERRAIN_TYPES.WATER && terrainType !== TERRAIN_TYPES.MOUNTAIN;
+        const isWater = terrainTypeAtNode === TERRAIN_TYPES.WATER;
+        const isMountain = terrainTypeAtNode === TERRAIN_TYPES.MOUNTAIN;
+        const result = !isWater && !isMountain;
+        console.log(`isTraversable (land unit): terrainTypeAtNode=${terrainTypeAtNode}. IsWater=${isWater}, IsMountain=${isMountain}. Result=${result}`);
+        return result;
     } else if (unitMovementType === 'amphibious') {
-        return terrainType !== TERRAIN_TYPES.MOUNTAIN; // Amphibious can traverse land and water
+        const isMountain = terrainTypeAtNode === TERRAIN_TYPES.MOUNTAIN;
+        const result = !isMountain;
+        console.log(`isTraversable (amphibious unit): terrainTypeAtNode=${terrainTypeAtNode}. IsMountain=${isMountain}. Result=${result}`);
+        return result;
     } else if (unitMovementType === 'air') {
-        return true; // Air units can traverse any terrain
+        console.log(`isTraversable (air unit): Result=true`);
+        return true;
     }
-    // Add other movement types if necessary
-    console.warn(`A* isTraversable: Unknown unitMovementType: ${unitMovementType}`);
+
+    console.log(`isTraversable: Unknown unitMovementType or fallthrough. unitMovementType='${unitMovementType}'. Result=false`);
     return false;
 }
 


### PR DESCRIPTION
- I modified the `isTraversable` function in `js/pathfinding/astar.js` to use `parseInt()` on the terrain type value read from the grid. This makes the comparison with numeric `TERRAIN_TYPES` constants more robust against potential string data in the terrain map.
- I added/ensured extensive console logging remains active in both `isTraversable` (for raw/parsed types, comparisons) and in `unit.js` (for movement type passed to A*, path following details) to aid in debugging pathfinding issues.
- I increased `WAYPOINT_REACH_THRESHOLD` in `unit.js` in a previous step to help with path following.

These changes are aimed at resolving the 'node not traversable' errors and helping to diagnose path following behavior. Further testing is required.