### PR TITLE
feat: Port Trikeshed core library from Kotlin to TypeScript

### DIFF
--- a/src/trikeshed/core.test.ts
+++ b/src/trikeshed/core.test.ts
@@ -1,0 +1,278 @@
+// src/trikeshed/core.test.ts
+
+import {
+    j, first, second, Join,
+    twin, Twin,
+    Series, size as seriesSize, getSeriesValue, emptySeries, materializeSeries, seriesCharToString,
+    Tensor, tensorShape, tensorAccessor, tensorRank, tensorTotalSize,
+    TensorConstruct, TensorSeries, TensorCursor,
+    getTensorValue, getTensorValueRank1, getTensorValueRank2,
+    alphaConvert, alphaConvertSeries,
+    linearToCoords, coordsToLinear, materialize,
+    broadcastShapes, /*calculateBroadcastCoordinateMap,*/ getCoordsForBroadcastedTensor, zip, combine, // Not testing all broadcasting utils in basic tests
+    CoreTensorCursor, CoreTensorRowVec, // CoreTensorColumnVec,
+    cursorRows, cursorCols, getRow, getCol,
+    IntRange, sliceCursorByRowRange, sliceCursorByColumnIndices, sliceCursorByColumnSeries,
+    TypeMemento, IOMementoType, IOMemento, ColumnMeta, columnName, columnType,
+    CursorMeta, CoreTensorCursorWithMeta, coreTensorMeta, meta as getCursorMeta, cursorMetaNames, // aliased meta to getCursorMeta
+    ColumnExclusion, excludeByName,
+    excludeColumnsByIndices, excludeColumnsByName, selectColumnsByName,
+    toDisplayString, head, show, showRandom, showValues, // Not all presentation fns will be easily testable without spies on console.log
+    isNumerical, isHomomorphic
+} from './core';
+
+// Mock console.log for presentation function tests if needed
+// let consoleLogSpy: jest.SpyInstance;
+// beforeEach(() => {
+//    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+// });
+// afterEach(() => {
+//    consoleLogSpy.mockRestore();
+// });
+
+
+describe('Trikeshed Core Library', () => {
+
+    describe('Join, Twin', () => {
+        it('should create a Join and access its properties', () => {
+            const myJoin: Join<number, string> = j(10, "hello");
+            expect(myJoin.a).toBe(10);
+            expect(myJoin.b).toBe("hello");
+            expect(first(myJoin)).toBe(10);
+            expect(second(myJoin)).toBe("hello");
+        });
+
+        it('should create a Twin', () => {
+            const myTwin: Twin<number> = twin(5);
+            expect(myTwin.a).toBe(5);
+            expect(myTwin.b).toBe(5);
+        });
+    });
+
+    describe('Series', () => {
+        it('should create a Series and access its properties and values', () => {
+            const mySeries: Series<number> = j(3, (i) => i * 2);
+            expect(seriesSize(mySeries)).toBe(3);
+            expect(getSeriesValue(mySeries, 0)).toBe(0);
+            expect(getSeriesValue(mySeries, 1)).toBe(2);
+            expect(getSeriesValue(mySeries, 2)).toBe(4);
+            expect(() => getSeriesValue(mySeries, 3)).toThrow(RangeError);
+        });
+
+        it('should handle EmptySeries', () => {
+            const es: Series<string> = emptySeries<string>();
+            expect(seriesSize(es)).toBe(0);
+            expect(() => getSeriesValue(es, 0)).toThrowError("Cannot access elements of an empty series.");
+        });
+
+        it('should materialize a Series to an iterable and then to an array', () => {
+            const mySeries: Series<number> = j(3, (i) => i + 1);
+            const iterable = materializeSeries(mySeries);
+            const arr = Array.from(iterable);
+            expect(arr).toEqual([1, 2, 3]);
+        });
+
+        it('should convert a Series of chars (strings) to a string', () => {
+            const charSeries: Series<string> = j(3, (i) => String.fromCharCode(97 + i)); // "a", "b", "c"
+            expect(seriesCharToString(charSeries)).toBe("abc");
+        });
+
+        it('should alphaConvert a Series', () => {
+            const mySeries: Series<number> = j(3, (i) => i + 1); // 1, 2, 3
+            const newSeries = alphaConvertSeries(mySeries, x => x * 10); // 10, 20, 30
+            expect(seriesSize(newSeries)).toBe(3);
+            expect(getSeriesValue(newSeries, 0)).toBe(10);
+            expect(getSeriesValue(newSeries, 1)).toBe(20);
+            expect(getSeriesValue(newSeries, 2)).toBe(30);
+        });
+    });
+
+    describe('Tensor', () => {
+        it('should create a Tensor and access its properties', () => {
+            const myTensor: Tensor<number> = TensorConstruct([2, 2], (coords) => coords[0] + coords[1]);
+            expect(tensorShape(myTensor)).toEqual([2, 2]);
+            expect(tensorRank(myTensor)).toBe(2);
+            expect(tensorTotalSize(myTensor)).toBe(4);
+            expect(getTensorValue(myTensor, [0, 1])).toBe(1);
+            expect(getTensorValueRank2(myTensor, 1, 1)).toBe(2);
+        });
+
+        it('should create TensorSeries (rank 1 tensor)', () => {
+            const ts: Tensor<string> = TensorSeries(3, (i) => `val${i}`);
+            expect(tensorRank(ts)).toBe(1);
+            expect(tensorShape(ts)).toEqual([3]);
+            expect(getTensorValueRank1(ts, 1)).toBe("val1");
+        });
+
+        it('should create TensorCursor (rank 2 tensor)', () => {
+            const tc: Tensor<number> = TensorCursor(2, 3, (r, c) => r * 10 + c);
+            expect(tensorRank(tc)).toBe(2);
+            expect(tensorShape(tc)).toEqual([2, 3]);
+            expect(getTensorValueRank2(tc, 1, 2)).toBe(12);
+        });
+
+        it('should perform alphaConvert on a Tensor', () => {
+            const myTensor: Tensor<number> = TensorConstruct([2,2], coords => coords[0] * 10 + coords[1]);
+            // 0,0 -> 0 | 0,1 -> 1
+            // 1,0 -> 10 | 1,1 -> 11
+            const newTensor = alphaConvert(myTensor, x => x + 5);
+            expect(getTensorValueRank2(newTensor, 0,0)).toBe(0+5);
+            expect(getTensorValueRank2(newTensor, 1,1)).toBe(11+5);
+        });
+
+        it('should convert linear index to coords and back', () => {
+            const tensor = TensorConstruct([2,3,4], () => 0); // Shape 2x3x4, total size 24
+            let coords = linearToCoords(tensor, 0); // Should be [0,0,0]
+            expect(coords).toEqual([0,0,0]);
+            expect(coordsToLinear(tensor, coords)).toBe(0);
+
+            coords = linearToCoords(tensor, 23); // Last element, should be [1,2,3]
+            expect(coords).toEqual([1,2,3]);
+            expect(coordsToLinear(tensor, coords)).toBe(23);
+
+            coords = linearToCoords(tensor, 5); // 5 -> [0,1,1] (0*12 + 1*4 + 1*1 = 5)
+            expect(coords).toEqual([0,1,1]);
+            expect(coordsToLinear(tensor, coords)).toBe(5);
+
+            expect(() => linearToCoords(tensor, 24)).toThrow(RangeError);
+            expect(() => coordsToLinear(tensor, [0,0,4])).toThrow(RangeError); // coord out of bounds
+        });
+
+        it('should materialize a Tensor to an array', () => {
+            const tensor: Tensor<number> = TensorCursor(2, 2, (r, c) => r === c ? 1 : 0); // Identity matrix
+            // 1 0
+            // 0 1
+            // Materializes row-major: 1, 0, 0, 1
+            expect(materialize(tensor)).toEqual([1, 0, 0, 1]);
+        });
+         it('should handle materialize on zero-dimension tensor', () => {
+            const tensorZ: Tensor<number> = TensorConstruct([2,0,3], () => 0);
+            expect(materialize(tensorZ)).toEqual([]);
+        });
+
+    });
+
+    describe('CoreTensorCursor', () => {
+        let cursor: CoreTensorCursor<number>;
+        beforeEach(() => {
+            cursor = TensorCursor(3, 4, (r,c) => r * 10 + c);
+            // 00 01 02 03
+            // 10 11 12 13
+            // 20 21 22 23
+        });
+
+        it('should get rows and cols counts', () => {
+            expect(cursorRows(cursor)).toBe(3);
+            expect(cursorCols(cursor)).toBe(4);
+        });
+
+        it('should get a row vector', () => {
+            const row1 = getRow(cursor, 1); // Second row: 10 11 12 13
+            expect(tensorRank(row1)).toBe(1);
+            expect(tensorShape(row1)).toEqual([4]);
+            expect(materialize(row1)).toEqual([10, 11, 12, 13]);
+        });
+
+        it('should get a column vector', () => {
+            const col0 = getCol(cursor, 0); // First col: 00 10 20
+            expect(tensorRank(col0)).toBe(1);
+            expect(tensorShape(col0)).toEqual([3]);
+            expect(materialize(col0)).toEqual([0, 10, 20]);
+        });
+
+        it('should slice by row range', () => {
+            const subCursor = sliceCursorByRowRange(cursor, {first: 1, last: 2}); // Rows 1 and 2
+            // 10 11 12 13
+            // 20 21 22 23
+            expect(cursorRows(subCursor)).toBe(2);
+            expect(cursorCols(subCursor)).toBe(4);
+            expect(getTensorValueRank2(subCursor, 0,0)).toBe(10); // original (1,0)
+            expect(getTensorValueRank2(subCursor, 1,3)).toBe(23); // original (2,3)
+        });
+
+        it('should slice by column indices (varargs)', () => {
+            const subCursor = sliceCursorByColumnIndices(cursor, 3, 1); // Columns 3 and 1 (in that order)
+            // 03 01
+            // 13 11
+            // 23 21
+            expect(cursorRows(subCursor)).toBe(3);
+            expect(cursorCols(subCursor)).toBe(2);
+            expect(getTensorValueRank2(subCursor, 0,0)).toBe(3);  // original (0,3)
+            expect(getTensorValueRank2(subCursor, 1,1)).toBe(11); // original (1,1)
+        });
+
+        it('should slice by column indices (Series)', () => {
+            const colIdxSeries: Series<number> = j(2, i => i === 0 ? 0 : 2); // Indices 0 and 2
+            const subCursor = sliceCursorByColumnSeries(cursor, colIdxSeries);
+            // 00 02
+            // 10 12
+            // 20 22
+            expect(cursorRows(subCursor)).toBe(3);
+            expect(cursorCols(subCursor)).toBe(2);
+            expect(getTensorValueRank2(subCursor, 0,0)).toBe(0); // original (0,0)
+            expect(getTensorValueRank2(subCursor, 2,1)).toBe(22); // original (2,2)
+        });
+    });
+
+    describe('Metadata and CursorWithMeta', () => {
+        let cwm: CoreTensorCursorWithMeta<string>;
+        let data: CoreTensorCursor<string>;
+        let metaData: CursorMeta;
+
+        beforeEach(() => {
+            data = TensorCursor(1, 2, (r, c) => `val_${r}_${c}`); // 1x2 data
+            const colMeta1: ColumnMeta = j("name", IOMemento[IOMementoType.IoString]);
+            const colMeta2: ColumnMeta = j("age", IOMemento[IOMementoType.IoInt]);
+            metaData = TensorSeries(2, i => (i === 0 ? colMeta1 : colMeta2)); // 2 columns of metadata
+            cwm = j(data, metaData);
+        });
+
+        it('should access data and metadata', () => {
+            expect(cursorRows(cwm.a)).toBe(1);
+            const currentMeta = getCursorMeta(cwm); // Using aliased import for meta
+            expect(tensorRank(currentMeta)).toBe(1);
+            expect(totalSize(currentMeta)).toBe(2);
+            expect(columnName(getTensorValueRank1(currentMeta, 0))).toBe("name");
+        });
+
+        it('should get cursor meta names', () => {
+            expect(cursorMetaNames(metaData)).toEqual(["name", "age"]);
+        });
+
+        it('should exclude columns by name', () => {
+            const exclusion = excludeByName("age");
+            const exclusionSeries = j(1, () => exclusion);
+            const newCwm = excludeColumnsByName(cwm, exclusionSeries);
+
+            expect(cursorCols(newCwm.a)).toBe(1);
+            expect(cursorMetaNames(getCursorMeta(newCwm))).toEqual(["name"]);
+            expect(getTensorValueRank2(newCwm.a, 0,0)).toBe("val_0_0");
+        });
+
+        it('should select columns by name', () => {
+            const newCwm = selectColumnsByName(cwm, "age"); // Select only "age"
+            expect(cursorCols(newCwm.a)).toBe(1);
+            expect(cursorMetaNames(getCursorMeta(newCwm))).toEqual(["age"]);
+            expect(getTensorValueRank2(newCwm.a, 0,0)).toBe("val_0_1"); // original data from age column
+        });
+
+        it('isNumerical and isHomomorphic', () => {
+            expect(isNumerical(cwm)).toBe(false); // "name" is string, "age" is Int
+
+            const colMetaNum1: ColumnMeta = j("num1", IOMemento[IOMementoType.IoFloat]);
+            const colMetaNum2: ColumnMeta = j("num2", IOMemento[IOMementoType.IoDouble]);
+            const metaNum = TensorSeries(2, i => (i === 0 ? colMetaNum1 : colMetaNum2));
+            const cwmNum = j(TensorCursor(1,2,() => 0), metaNum);
+            expect(isNumerical(cwmNum)).toBe(true);
+            expect(isHomomorphic(cwmNum)).toBe(false); // Float and Double are different types
+
+            const metaHomo = TensorSeries(2, () => colMetaNum1); // Both Float
+            const cwmHomo = j(TensorCursor(1,2,() => 0), metaHomo);
+            expect(isHomomorphic(cwmHomo)).toBe(true);
+        });
+    });
+
+    // TODO: Add tests for broadcasting functions (broadcastShapes, combine, zip)
+    // TODO: Add tests for presentation functions (mock console.log to check output format)
+
+});

--- a/src/trikeshed/core.ts
+++ b/src/trikeshed/core.ts
@@ -1,0 +1,993 @@
+// src/trikeshed/core.ts
+
+// Suppressing TSLint/ESLint rules similar to Kotlin's @file:Suppress
+// For TSLint (deprecated but common in older TS projects):
+// tslint:disable:interface-name function-name object-literal-sort-keys no-any non-literal-fs-path prefer-for-of no-unnecessary-type-assertion no-shadowed-variable
+
+// For ESLint (modern standard):
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/interface-name-prefix */ // For IJoin if we used I prefix
+/* eslint-disable @typescript-eslint/class-name-casing */ // For _Join if we used class _Join
+/* eslint-disable no-shadow */ // For potential name shadowing if simple names are used
+/* eslint-disable @typescript-eslint/no-unused-vars */ // For generic types that might not be used in all base definitions
+
+// I. Trikeshed Essentials: Join and Series Primitives
+
+/**
+ * Interface representing a fundamental Join operation, similar to a Pair but with named `a` and `b` components.
+ */
+export interface Join<A, B> {
+    readonly a: A;
+    readonly b: B;
+    // component1 and component2 are idiomatic in Kotlin for destructuring
+    // In TypeScript, direct property access or object destructuring is common: const { a, b } = myJoin;
+}
+
+/**
+ * Creates a Join instance. This is the primary construction mechanism.
+ * Kotlin's infix fun <A, B> A.j(b: B): Join<A, B> translates to a function.
+ */
+export function j<A, B>(firstParam: A, secondParam: B): Join<A, B> {
+    return { a: firstParam, b: secondParam };
+}
+
+/** Accessor for the first element of a Join. */
+export function first<A, B>(join: Join<A, B>): A {
+    return join.a;
+}
+
+/** Accessor for the second element of a Join. */
+export function second<A, B>(join: Join<A, B>): B {
+    return join.b;
+}
+
+/**
+ * Type alias for a Join where both elements are of the same type.
+ */
+export type Twin<T> = Join<T, T>;
+
+/**
+ * Factory function to create a Twin from a single value.
+ */
+export function twin<T>(value: T): Twin<T> {
+    return j(value, value);
+}
+
+/**
+ * Type alias for a Series, which is a Join of a size (number) and an accessor function.
+ * This represents a lazily-evaluated sequence of elements indexed by an integer.
+ */
+export type Series<T> = Join<number, (index: number) => T>;
+
+/** Returns the size of the Series. */
+export function size<T>(series: Series<T>): number {
+    return series.a;
+}
+
+/**
+ * Operator to access an element of the Series by its index.
+ * Kotlin's operator fun <T> Series<T>.get(i: Int): T translates to a function.
+ */
+export function getSeriesValue<T>(series: Series<T>, i: number): T {
+    if (i < 0 || i >= size(series)) {
+        throw new RangeError(`Index ${i} out of bounds for Series of size ${size(series)}`);
+    }
+    return series.b(i);
+}
+
+/**
+ * An empty Series instance.
+ * Note: Typing `EmptySeries` as `Series<any>` or `Series<unknown>` is safer.
+ * Casting to `Series<T>` should be done carefully by the caller.
+ */
+export const EmptySeries: Series<any> = j(0, (_index: number) => {
+    throw new Error("Cannot access elements of an empty series.");
+});
+
+/**
+ * Factory function to create an empty Series.
+ */
+export function emptySeries<T>(): Series<T> {
+    return EmptySeries as Series<T>;
+}
+
+/**
+ * Creates a lazy supplier (a lambda with no arguments) that returns `this` value.
+ * Kotlin's inline val <T> T.leftIdentity: () -> T translates to a function.
+ */
+export function leftIdentity<T>(value: T): () => T {
+    return () => value;
+}
+
+/**
+ * Syntactic sugar for leftIdentity.
+ * Kotlin's `↺` is not a valid identifier in JS/TS.
+ */
+export function circularRef<T>(value: T): () => T {
+    return leftIdentity(value);
+}
+
+/**
+ * A class wrapper around Series that makes it Iterable.
+ * Kotlin's value class IterableSeries<A>(val s: Series<A>)
+ */
+export class IterableSeries<A> implements Iterable<A>, Series<A> {
+    readonly a: number; // size
+    readonly b: (index: number) => A; // accessor
+
+    constructor(public readonly series: Series<A>) {
+        this.a = size(series);
+        this.b = series.b;
+    }
+
+    [Symbol.iterator](): Iterator<A> {
+        let index = 0;
+        const currentSeries = this.series; // Capture series instance for the iterator
+        return {
+            next: (): IteratorResult<A> => {
+                if (index < size(currentSeries)) {
+                    return { value: getSeriesValue(currentSeries, index++), done: false };
+                } else {
+                    return { value: undefined as any, done: true }; // `value: undefined` is fine for done:true
+                }
+            },
+        };
+    }
+
+    // Series interface implementation
+    get size(): number { return this.a; }
+    get(i: number): A { return getSeriesValue(this.series, i); }
+}
+
+/**
+ * Provides an Iterable view of the Series.
+ * Kotlin's `▶` (materialize) becomes a function.
+ */
+export function materializeSeries<T>(series: Series<T>): IterableSeries<T> {
+    return new IterableSeries(series);
+}
+
+/**
+ * Extension function to convert a Series of Char to a String.
+ * In TypeScript, this would be a standalone function.
+ */
+export function seriesCharToString(series: Series<string>): string {
+    // Assuming Series<string> where each string is a single character
+    let result = "";
+    for (const char of materializeSeries(series)) {
+        result += char;
+    }
+    return result;
+}
+
+
+// III. core.Tensor Implementation
+
+/**
+ * Type alias for a Tensor, which is a Join of its shape (number[]) and an accessor function
+ * that takes coordinates (number[]) and returns an element.
+ */
+export type Tensor<T> = Join<number[], (coords: number[]) => T>;
+
+/** Returns the shape of the Tensor. */
+export function tensorShape<T>(tensor: Tensor<T>): number[] {
+    return tensor.a;
+}
+/** Returns the accessor function of the Tensor. */
+export function tensorAccessor<T>(tensor: Tensor<T>): (coords: number[]) => T {
+    return tensor.b;
+}
+
+// Syntactic sugar often directly uses the more verbose names in TS if they are clear enough,
+// or short forms are provided as simple const/functions.
+export const shape = tensorShape;
+export const accessor = tensorAccessor;
+
+
+/** Returns the rank (number of dimensions) of the Tensor. */
+export function tensorRank<T>(tensor: Tensor<T>): number {
+    return tensorShape(tensor).length;
+}
+export const rank = tensorRank;
+
+/** Returns the total number of elements in the Tensor. */
+export function tensorTotalSize<T>(tensor: Tensor<T>): number {
+    const s = tensorShape(tensor);
+    if (s.length === 0) return 0; // Or 1 for a scalar if shape is like [] meaning one value
+                                   // Kotlin code implies 0 for empty shape.
+    return s.reduce((acc, i) => acc * i, 1); // Start with 1 for multiplication identity
+}
+export const totalSize = tensorTotalSize;
+
+/**
+ * Constructs a Tensor from a given shape and accessor function.
+ */
+export function TensorConstruct<T>(shape: number[], accessor: (coords: number[]) => T): Tensor<T> {
+    return j(shape, accessor);
+}
+
+/**
+ * Constructs a 1-dimensional Tensor (a "Series" in this context) from a size and an accessor function.
+ */
+export function TensorSeries<T>(size: number, accessor: (index: number) => T): Tensor<T> {
+    return TensorConstruct([size], (coords: number[]) => accessor(coords[0]));
+}
+
+/**
+ * Constructs a 2-dimensional Tensor (a "Cursor") from rows, columns, and an accessor function.
+ */
+export function TensorCursor<T>(rows: number, cols: number, accessor: (row: number, col: number) => T): Tensor<T> {
+    return TensorConstruct([rows, cols], (coords: number[]) => accessor(coords[0], coords[1]));
+}
+
+/**
+ * Invokes the Tensor's accessor with the given coordinates array.
+ */
+export function getTensorValue<T>(tensor: Tensor<T>, coords: number[]): T {
+    // Basic validation, more can be added (e.g., rank check, coord bounds)
+    if (coords.length !== rank(tensor)) {
+        throw new Error(`Coordinate rank mismatch: Tensor rank is ${rank(tensor)}, got ${coords.length} coordinates.`);
+    }
+    return tensorAccessor(tensor)(coords);
+}
+
+/**
+ * Invokes the Tensor's accessor with the given variable arguments for coordinates.
+ * In TS, this is achieved using rest parameters.
+ */
+export function getTensorValueVarArgs<T>(tensor: Tensor<T>, ...coords: number[]): T {
+    return getTensorValue(tensor, coords);
+}
+
+// For specific ranks, we can provide convenience functions like Kotlin's invoke operators.
+// These are not direct operator overloads in TS.
+
+/**
+ * Gets a value from a 1-dimensional Tensor with a single coordinate.
+ */
+export function getTensorValueRank1<T>(tensor: Tensor<T>, i: number): T {
+    if (rank(tensor) !== 1) {
+        throw new Error(`Tensor is not rank 1. Current rank: ${rank(tensor)}`);
+    }
+    return tensorAccessor(tensor)([i]);
+}
+
+/**
+ * Gets a value from a 2-dimensional Tensor with row and column coordinates.
+ */
+export function getTensorValueRank2<T>(tensor: Tensor<T>, i: number, j: number): T {
+    if (rank(tensor) !== 2) {
+        throw new Error(`Tensor is not rank 2. Current rank: ${rank(tensor)}`);
+    }
+    return tensorAccessor(tensor)([i, j]);
+}
+
+// End of Part 1 of translation
+
+// File: src/trikeshed/core.ts (appending)
+
+// IV. Core Tensor Operations
+
+/**
+ * Applies a transformation function element-wise to a Tensor, producing a new Tensor
+ * with the same shape. This is an "alpha-conversion" operation.
+ * Kotlin: infix fun <X, C> Tensor<X>.α(crossinline transform: (X) -> C): Tensor<C>
+ */
+export function alphaConvert<X, C>(tensor: Tensor<X>, transform: (value: X) -> C): Tensor<C> {
+    return TensorConstruct(tensorShape(tensor), (coords: number[]) => transform(getTensorValue(tensor, coords)));
+}
+
+/**
+ * Applies a transformation function element-wise to a Series, producing a new Series.
+ * Kotlin: inline infix fun <X, C> Series<X>.α(crossinline transform: (X) -> C): Series<C>
+ */
+export function alphaConvertSeries<X, C>(series: Series<X>, transform: (value: X) -> C): Series<C> {
+    return j(size(series), (i: number) => transform(getSeriesValue(series, i)));
+}
+
+
+/**
+ * Converts a linear index into multi-dimensional coordinates based on the Tensor's shape.
+ */
+export function linearToCoords(tensor: Tensor<any>, linearIndex: number): number[] {
+    const s = shape(tensor);
+    const r = rank(tensor);
+    const coords = new Array(r).fill(0);
+    let remaining = linearIndex;
+
+    if (r === 0 && linearIndex === 0) return []; // Scalar case, empty coords
+    if (r === 0 && linearIndex !== 0) throw new RangeError("Linear index out of bounds for scalar tensor.");
+
+
+    for (let i = r - 1; i >= 0; i--) {
+        const dimSize = s[i];
+        if (dimSize === 0 && remaining !== 0) throw new Error("Cannot map linear index in zero-sized dimension");
+        if (dimSize === 0) { // If dimension size is 0, coordinate must be 0
+            coords[i] = 0;
+            continue;
+        }
+        coords[i] = remaining % dimSize;
+        remaining = Math.floor(remaining / dimSize);
+    }
+
+    if (remaining !== 0) {
+        // This indicates the linearIndex was too large for the tensor's total size.
+        throw new RangeError(`Linear index ${linearIndex} is out of bounds for tensor with shape ${s.join(',')}. Remaining: ${remaining}`);
+    }
+    return coords;
+}
+
+/**
+ * Converts multi-dimensional coordinates into a linear index based on the Tensor's shape.
+ */
+export function coordsToLinear(tensor: Tensor<any>, coords: number[]): number {
+    const s = shape(tensor);
+    const r = rank(tensor);
+
+    if (r === 0 && coords.length === 0) return 0; // Scalar case
+    if (r === 0 && coords.length !== 0) throw new Error("Coordinates provided for scalar tensor.");
+
+
+    if (coords.length !== r) {
+        throw new Error(`Coordinate rank mismatch: expected ${r}, got ${coords.length}`);
+    }
+
+    let linearIndex = 0;
+    let multiplier = 1;
+    for (let i = r - 1; i >= 0; i--) {
+        const coordVal = coords[i];
+        const dimSize = s[i];
+        if (coordVal < 0 || coordVal >= dimSize) {
+            throw new RangeError(`Coordinate out of bounds: coords[${i}]=${coordVal} for dimension ${i} with size ${dimSize}`);
+        }
+        linearIndex += coordVal * multiplier;
+        multiplier *= dimSize;
+    }
+    return linearIndex;
+}
+
+/**
+ * Materializes the entire content of a Tensor into a flat Array.
+ * Note: This can be memory-intensive for large tensors.
+ * The order of elements in the array is row-major (C-style).
+ */
+export function materialize<T>(tensor: Tensor<T>): T[] {
+    const tSize = totalSize(tensor);
+    if (tSize === 0 && shape(tensor).length > 0 && shape(tensor).some(d => d === 0) ) return []; // Tensor with a zero dimension
+    if (tSize === 0 && shape(tensor).length === 0) return []; // True scalar but no elements (empty shape) - though totalSize might be 1 for scalar
+                                                             // Kotlin code returns totalSize=0 for empty shape. So this should be okay.
+
+    const arr: T[] = new Array(tSize);
+    for (let i = 0; i < tSize; i++) {
+        arr[i] = getTensorValue(tensor, linearToCoords(tensor, i));
+    }
+    return arr;
+}
+
+
+/**
+ * Determines the broadcasted shape for two input shapes.
+ * Dimensions are aligned from the right. A dimension can broadcast if it's equal or one of them is 1.
+ */
+export function broadcastShapes(shape1: number[], shape2: number[]): number[] {
+    const maxRank = Math.max(shape1.length, shape2.length);
+    const result = new Array(maxRank).fill(0);
+
+    for (let i = 0; i < maxRank; i++) {
+        const dim1 = (i < shape1.length) ? shape1[shape1.length - 1 - i] : 1;
+        const dim2 = (i < shape2.length) ? shape2[shape2.length - 1 - i] : 1;
+
+        if (dim1 !== dim2 && dim1 !== 1 && dim2 !== 1) {
+            throw new Error(`Shapes are not broadcastable: [${shape1}] vs [${shape2}] at aligned index ${i}`);
+        }
+        result[maxRank - 1 - i] = Math.max(dim1, dim2);
+    }
+    return result;
+}
+
+/**
+ * A helper function for broadcasting, as provided in the Kotlin summary.
+ * Translates the logic from:
+ * fun IntArray.broadcastTo(targetShape: IntArray): IntArray
+ * This function calculates how a source shape (`thisShape`) needs to be adjusted or interpreted
+ * to fit a `targetShape` during broadcasting operations.
+ * The Kotlin version's logic was: "if sourceIndex < this.size && this[sourceIndex] < targetShape[i] then this[sourceIndex] else 0"
+ * This seems to imply it's creating a coordinate mapping or mask.
+ * A more common interpretation of `broadcastTo` for coordinates might be to adjust input coordinates
+ * for a smaller shape to be valid for a larger broadcasted shape (e.g., if a dimension was 1, use 0, else use original coord).
+ * Let's stick to the literal translation of the provided Kotlin logic.
+ */
+export function calculateBroadcastCoordinateMap(sourceShape: number[], targetShape: number[]): number[] {
+    const result = new Array(targetShape.length).fill(0);
+    const offset = targetShape.length - sourceShape.length;
+
+    for (let i = 0; i < targetShape.length; i++) {
+        if (i < offset) { // Target dimension is beyond source shape's rank (left-padded)
+            result[i] = 0; // Or perhaps this should throw error or handle based on broadcasting rules if sourceShape[0] is not 1
+        } else {
+            const sourceIndex = i - offset;
+            // Original Kotlin logic:
+            // if (sourceIndex < sourceShape.length && sourceShape[sourceIndex] < targetShape[i]) { result[i] = sourceShape[sourceIndex]; } else { result[i] = 0; }
+            // This logic seems unusual for typical broadcasting coordinate calculation.
+            // A typical broadcasting coordinate adjustment would be:
+            // if (sourceShape[sourceIndex] === 1) result[i] = 0; else result[i] = targetCoords[i];
+            // Given the ambiguity, I will translate the provided Kotlin logic directly.
+            if (sourceIndex < sourceShape.length && sourceShape[sourceIndex] < targetShape[i]) {
+                result[i] = sourceShape[sourceIndex];
+            } else {
+                result[i] = 0;
+            }
+        }
+    }
+    return result;
+    // IMPORTANT: The utility of this specific `broadcastTo` logic needs review.
+    // The typical use of broadcasting in zip/combine is to make coordinates for the smaller tensor
+    // effectively 0 for dimensions that were 1, or use the coordinate directly if the dimension matched.
+}
+
+
+/**
+ * Adjusts coordinates for a tensor that has been broadcast to a target shape.
+ * If a dimension in the original tensor was 1, the coordinate for that dimension becomes 0.
+ * Otherwise, the coordinate from the target shape is used.
+ * @param originalShape The shape of the tensor before broadcasting.
+ * @param broadcastedCoords The coordinates in the context of the broadcasted shape.
+ * @returns Coordinates suitable for accessing the original tensor.
+ */
+function getCoordsForBroadcastedTensor(originalShape: number[], broadcastedCoords: number[]): number[] {
+    const resultCoords = new Array(originalShape.length).fill(0);
+    const rankDiff = broadcastedCoords.length - originalShape.length;
+
+    for (let i = 0; i < originalShape.length; i++) {
+        const originalDimSize = originalShape[i];
+        const broadcastedCoordValue = broadcastedCoords[i + rankDiff];
+        if (originalDimSize === 1) {
+            resultCoords[i] = 0;
+        } else {
+            resultCoords[i] = broadcastedCoordValue;
+        }
+    }
+    return resultCoords;
+}
+
+
+/**
+ * Zips two Tensors element-wise, creating a new Tensor of Join pairs.
+ * The shapes are broadcasted if compatible.
+ */
+export function zip<A, B>(tensorA: Tensor<A>, tensorB: Tensor<B>): Tensor<Join<A, B>> {
+    const broadcastedShapeResult = broadcastShapes(shape(tensorA), shape(tensorB));
+
+    return TensorConstruct(broadcastedShapeResult, (coords: number[]) => {
+        const valA = getTensorValue(tensorA, getCoordsForBroadcastedTensor(shape(tensorA), coords));
+        const valB = getTensorValue(tensorB, getCoordsForBroadcastedTensor(shape(tensorB), coords));
+        return j(valA, valB);
+    });
+}
+
+/**
+ * Combines two Tensors element-wise using a transformation function,
+ * producing a new Tensor. Shapes are broadcasted if compatible.
+ */
+export function combine<A, B, C>(
+    tensorA: Tensor<A>,
+    tensorB: Tensor<B>,
+    transform: (valA: A, valB: B) => C
+): Tensor<C> {
+    const broadcastedShapeResult = broadcastShapes(shape(tensorA), shape(tensorB));
+
+    return TensorConstruct(broadcastedShapeResult, (coords: number[]) => {
+        const valA = getTensorValue(tensorA, getCoordsForBroadcastedTensor(shape(tensorA), coords));
+        const valB = getTensorValue(tensorB, getCoordsForBroadcastedTensor(shape(tensorB), coords));
+        return transform(valA, valB);
+    });
+}
+
+// End of Part 2 of translation (Core Tensor Operations)
+
+// File: src/trikeshed/core.ts (appending)
+
+// V. CoreTensorCursor Layer
+
+/**
+ * Type alias for a Tensor specialized to represent a Cursor (a 2D structure like a table).
+ * It's expected to be a Tensor of rank 2.
+ */
+export type CoreTensorCursor<T> = Tensor<T>;
+
+/**
+ * Type alias for a 1-dimensional Tensor representing a row vector within a cursor.
+ * It's expected to be a Tensor of rank 1.
+ */
+export type CoreTensorRowVec<T> = Tensor<T>;
+
+/**
+ * Type alias for a 1-dimensional Tensor representing a column vector within a cursor.
+ * It's expected to be a Tensor of rank 1.
+ */
+export type CoreTensorColumnVec<T> = Tensor<T>;
+
+// Forward declaration for ColumnMeta if not fully defined yet, or ensure it's imported/available
+// Assuming ColumnMeta will be defined in section VI. For now, a placeholder if needed.
+// export type ColumnMeta = Join<string, TypeMemento>; // Will be defined later
+
+/**
+ * Type alias for a Tensor holding ColumnMeta objects, representing the metadata for cursor columns.
+ * This is a 1D Tensor where each element is a ColumnMeta.
+ */
+export type CursorMeta = Tensor<ColumnMeta>; // ColumnMeta to be defined in next section
+
+/**
+ * Type alias for a Join that combines a CoreTensorCursor (the data) with its CursorMeta (the schema).
+ */
+export type CoreTensorCursorWithMeta<T> = Join<CoreTensorCursor<T>, CursorMeta>;
+
+/** Returns the number of rows in a CoreTensorCursor. */
+export function cursorRows<T>(cursor: CoreTensorCursor<T>): number {
+    const s = shape(cursor);
+    if (s.length !== 2) throw new Error("Cursor must be rank 2 to have rows.");
+    return s[0];
+}
+
+/** Returns the number of columns in a CoreTensorCursor. */
+export function cursorCols<T>(cursor: CoreTensorCursor<T>): number {
+    const s = shape(cursor);
+    if (s.length !== 2) throw new Error("Cursor must be rank 2 to have columns.");
+    return s[1];
+}
+
+/**
+ * Extracts a row as a CoreTensorRowVec (rank-1 Tensor) from a 2-dimensional CoreTensorCursor.
+ */
+export function getRow<T>(cursor: CoreTensorCursor<T>, rowIndex: number): CoreTensorRowVec<T> {
+    if (rank(cursor) !== 2) {
+        throw new Error("Cursor must be rank 2 for row access.");
+    }
+    const numRows = cursorRows(cursor);
+    if (rowIndex < 0 || rowIndex >= numRows) {
+        throw new RangeError(`Row index ${rowIndex} out of bounds for cursor with ${numRows} rows.`);
+    }
+    const numCols = cursorCols(cursor);
+    return TensorSeries(numCols, (colIdx: number) => getTensorValueRank2(cursor, rowIndex, colIdx));
+}
+
+/**
+ * Extracts a column as a CoreTensorColumnVec (rank-1 Tensor) from a 2-dimensional CoreTensorCursor.
+ */
+export function getCol<T>(cursor: CoreTensorCursor<T>, colIndex: number): CoreTensorColumnVec<T> {
+    if (rank(cursor) !== 2) {
+        throw new Error("Cursor must be rank 2 for column access.");
+    }
+    const numCols = cursorCols(cursor);
+    if (colIndex < 0 || colIndex >= numCols) {
+        throw new RangeError(`Column index ${colIndex} out of bounds for cursor with ${numCols} columns.`);
+    }
+    const numRows = cursorRows(cursor);
+    return TensorSeries(numRows, (rowIdx: number) => getTensorValueRank2(cursor, rowIdx, colIndex));
+}
+
+/**
+ * Represents a simple integer range (inclusive start, exclusive end, like slice).
+ * Or (inclusive start, inclusive end) if that matches Kotlin's IntRange more closely for this context.
+ * Kotlin's `IntRange.last` is inclusive. So, `first` to `last` inclusive.
+ */
+export interface IntRange {
+    first: number;
+    last: number; // Inclusive
+}
+
+/**
+ * Slices a CoreTensorCursor by a range of rows, returning a new CoreTensorCursor.
+ * Kotlin: operator fun <T> CoreTensorCursor<T>.get(rowRange: IntRange): CoreTensorCursor<T>
+ */
+export function sliceCursorByRowRange<T>(cursor: CoreTensorCursor<T>, rowRange: IntRange): CoreTensorCursor<T> {
+    if (rank(cursor) !== 2) {
+        throw new Error("Cursor must be rank 2 for row range slicing.");
+    }
+    const numRows = cursorRows(cursor);
+    if (rowRange.first < 0 || rowRange.last >= numRows || rowRange.first > rowRange.last) {
+        throw new RangeError(`Row range {first: ${rowRange.first}, last: ${rowRange.last}} out of bounds for cursor with ${numRows} rows.`);
+    }
+
+    const newNumRows = rowRange.last - rowRange.first + 1;
+    const numCols = cursorCols(cursor);
+
+    return TensorCursor(newNumRows, numCols, (r: number, c: number) => {
+        return getTensorValueRank2(cursor, rowRange.first + r, c);
+    });
+}
+
+/**
+ * Slices a CoreTensorCursor by specific column indices (varargs), returning a new CoreTensorCursor.
+ * Kotlin: operator fun <T> CoreTensorCursor<T>.get(vararg colIndices: Int): CoreTensorCursor<T>
+ */
+export function sliceCursorByColumnIndices<T>(cursor: CoreTensorCursor<T>, ...colIndices: number[]): CoreTensorCursor<T> {
+    if (rank(cursor) !== 2) {
+        throw new Error("Cursor must be rank 2 for column indexing.");
+    }
+    const numCols = cursorCols(cursor);
+    colIndices.forEach(ci => {
+        if (ci < 0 || ci >= numCols) {
+            throw new RangeError(`Column index ${ci} out of bounds for cursor with ${numCols} columns.`);
+        }
+    });
+
+    const numRows = cursorRows(cursor);
+    const newNumCols = colIndices.length;
+
+    return TensorCursor(numRows, newNumCols, (r: number, c: number) => {
+        return getTensorValueRank2(cursor, r, colIndices[c]);
+    });
+}
+
+/**
+ * Slices a CoreTensorCursor by specific column indices provided as a Series<number>.
+ * Kotlin: operator fun <T> CoreTensorCursor<T>.get(colIndices: Series<Int>): CoreTensorCursor<T>
+ */
+export function sliceCursorByColumnSeries<T>(cursor: CoreTensorCursor<T>, colIndicesSeries: Series<number>): CoreTensorCursor<T> {
+    if (rank(cursor) !== 2) {
+        throw new Error("Cursor must be rank 2 for column indexing.");
+    }
+    const numCols = cursorCols(cursor);
+    const indicesArray: number[] = [];
+    // Materialize Series to array for easier processing and validation
+    for (const index of materializeSeries(colIndicesSeries)) {
+        if (index < 0 || index >= numCols) {
+            throw new RangeError(`Column index ${index} from series out of bounds for cursor with ${numCols} columns.`);
+        }
+        indicesArray.push(index);
+    }
+
+    const numRows = cursorRows(cursor);
+    const newNumCols = indicesArray.length;
+
+    if (newNumCols === 0 && numRows > 0) { // Handle case of slicing to zero columns
+        return TensorCursor(numRows, 0, (_r, _c) => {
+            throw new Error("Cannot access data in a zero-column cursor");
+        });
+    }
+    if (numRows === 0 && newNumCols > 0 ) { // Handle case of slicing a zero-row cursor
+         return TensorCursor(0, newNumCols, (_r, _c) => {
+            throw new Error("Cannot access data in a zero-row cursor");
+        });
+    }
+     if (numRows === 0 && newNumCols === 0 ) { // Handle case of slicing a zero-row cursor to zero columns
+         return TensorCursor(0, 0, (_r, _c) => {
+            throw new Error("Cannot access data in a zero-row zero-column cursor");
+        });
+    }
+
+
+    return TensorCursor(numRows, newNumCols, (r: number, c: number) => {
+        return getTensorValueRank2(cursor, r, indicesArray[c]);
+    });
+}
+
+// End of Part 3 of translation (CoreTensorCursor Layer)
+
+// File: src/trikeshed/core.ts (appending)
+
+// VI. Metadata Types
+
+/**
+ * Interface for type metadata, used within ColumnMeta.
+ */
+export interface TypeMemento {
+    // In Kotlin, networkSize was nullable. In TS, optional property.
+    readonly networkSize?: number;
+    // Add a general type identifier, useful for TS.
+    readonly typeName: string;
+}
+
+/**
+ * Enum defining various I/O and data types used in the system,
+ * implementing TypeMemento.
+ */
+export enum IOMementoType {
+    IoByte = "Byte",
+    IoShort = "Short",
+    IoInt = "Int",
+    IoFloat = "Float",
+    IoDouble = "Double",
+    IoLong = "Long", // BigInt in JS/TS
+    IoBoolean = "Boolean",
+    IoChar = "Char", // string in JS/TS (single char)
+    IoString = "String",
+    IoCharSeries = "CharSeries", // Series<string>
+    IoBigDecimal = "BigDecimal", // No direct JS equivalent, typically string or library
+    IoBigInt = "BigInt", // BigInt in JS/TS
+    IoDateTime = "DateTime", // Date object or string/number
+    IoDuration = "Duration", // number (e.g., ms) or structured object
+    IoUUID = "UUID", // string
+    IoBinary = "Binary", // Uint8Array or similar
+    IoUnknown = "Unknown"
+}
+
+// Create a mapping from enum values to TypeMemento objects
+// This allows treating IOMementoType values as TypeMemento instances.
+export const IOMemento: { [key in IOMementoType]: TypeMemento } = Object.values(IOMementoType).reduce((acc, typeName) => {
+    acc[typeName] = { typeName: typeName }; // networkSize can be added if specific sizes are known
+    return acc;
+}, {} as { [key in IOMementoType]: TypeMemento });
+
+
+/**
+ * Type alias for column metadata, a Join of a column name (string) and its TypeMemento.
+ */
+export type ColumnMeta = Join<string, TypeMemento>;
+
+/** Returns the name of the column from ColumnMeta. */
+export function columnName(colMeta: ColumnMeta): string {
+    return colMeta.a;
+}
+/** Returns the type memento of the column from ColumnMeta. */
+export function columnType(colMeta: ColumnMeta): TypeMemento {
+    return colMeta.b;
+}
+
+/**
+ * Returns the CursorMeta component (the metadata Tensor) from a CoreTensorCursorWithMeta.
+ */
+export function coreTensorMeta<T>(ctcm: CoreTensorCursorWithMeta<T>): CursorMeta {
+    return ctcm.b;
+}
+/** Syntactic sugar for coreTensorMeta. */
+export const meta = coreTensorMeta;
+
+/** Returns a List (Array in TS) of column names from CursorMeta. */
+export function cursorMetaNames(cm: CursorMeta): string[] {
+    // CursorMeta is Tensor<ColumnMeta>, so materialize it then map.
+    return materialize(cm).map(colMeta => columnName(colMeta));
+}
+
+// VII. ColumnExclusion
+
+/**
+ * A class used to specify a column to be excluded by its name.
+ * Kotlin: @JvmInline value class ColumnExclusion(val name: String)
+ */
+export class ColumnExclusion {
+    constructor(public readonly name: string) {}
+    toString(): string { return `ColumnExclusion(${this.name})`; }
+}
+
+/**
+ * Helper function to create a ColumnExclusion (equivalent to Kotlin's String.unaryMinus).
+ * Example: excludeByName("columnName")
+ */
+export function excludeByName(name: string): ColumnExclusion {
+    return new ColumnExclusion(name);
+}
+
+/**
+ * Returns a new CoreTensorCursorWithMeta with columns excluded by their indices.
+ * Kotlin: operator fun <T> CoreTensorCursorWithMeta<T>.minus(killbag: Series<Int>)
+ */
+export function excludeColumnsByIndices<T>(
+    ctcm: CoreTensorCursorWithMeta<T>,
+    indicesToExcludeSeries: Series<number>
+): CoreTensorCursorWithMeta<T> {
+    const currentMeta = meta(ctcm);
+    const totalCols = totalSize(currentMeta); // totalSize of CursorMeta is number of columns
+    const allIndices = new Set<number>();
+    for(let i=0; i < totalCols; ++i) allIndices.add(i);
+
+    const indicesToExclude = new Set<number>();
+    for (const idx of materializeSeries(indicesToExcludeSeries)) {
+        indicesToExclude.add(idx);
+    }
+
+    const retainedIndicesArray: number[] = [];
+    allIndices.forEach(idx => {
+        if (!indicesToExclude.has(idx)) {
+            retainedIndicesArray.push(idx);
+        }
+    });
+
+    const newCursorData = sliceCursorByColumnIndices(ctcm.a, ...retainedIndicesArray);
+    const newMetaCursor = sliceCursorByColumnIndices(currentMeta, ...retainedIndicesArray); // Slice the meta tensor
+
+    return j(newCursorData, newMetaCursor);
+}
+
+/**
+ * Returns a new CoreTensorCursorWithMeta with columns excluded by ColumnExclusion objects (by name).
+ * Kotlin: fun <T> CoreTensorCursorWithMeta<T>.exclude(s: Series<ColumnExclusion>)
+ */
+export function excludeColumnsByName<T>(
+    ctcm: CoreTensorCursorWithMeta<T>,
+    exclusionsSeries: Series<ColumnExclusion>
+): CoreTensorCursorWithMeta<T> {
+    const currentMeta = meta(ctcm);
+    const names = cursorMetaNames(currentMeta); // Array of current column names
+
+    const namesToExclude = new Set<string>();
+    for (const exclusion of materializeSeries(exclusionsSeries)) {
+        namesToExclude.add(exclusion.name);
+    }
+
+    const indicesToRetain: number[] = [];
+    names.forEach((name, index) => {
+        if (!namesToExclude.has(name)) {
+            indicesToRetain.push(index);
+        }
+    });
+
+    const newCursorData = sliceCursorByColumnIndices(ctcm.a, ...indicesToRetain);
+    const newMetaCursor = sliceCursorByColumnIndices(currentMeta, ...indicesToRetain);
+
+    return j(newCursorData, newMetaCursor);
+}
+
+/**
+ * Gets a subset of columns from CoreTensorCursorWithMeta by their names.
+ * Kotlin: fun <T> CoreTensorCursorWithMeta<T>.get(vararg s: String)
+ */
+export function selectColumnsByName<T>(
+    ctcm: CoreTensorCursorWithMeta<T>,
+    ...columnNames: string[]
+): CoreTensorCursorWithMeta<T> {
+    const currentMeta = meta(ctcm);
+    const allCurrentNames = cursorMetaNames(currentMeta); // Array of current column names
+
+    const indicesToRetain: number[] = [];
+    const nameSet = new Set(columnNames); // For efficient lookup
+
+    allCurrentNames.forEach((name, index) => {
+        if (nameSet.has(name)) {
+            indicesToRetain.push(index);
+        }
+    });
+
+    // Preserve order of selection if columnNames implies order, but here we iterate through current order
+    // If specific order of `columnNames` is required for the new cursor, map `columnNames` to indices first.
+    // Current implementation retains original relative order of selected columns.
+
+    const newCursorData = sliceCursorByColumnIndices(ctcm.a, ...indicesToRetain);
+    const newMetaCursor = sliceCursorByColumnIndices(currentMeta, ...indicesToRetain);
+
+    return j(newCursorData, newMetaCursor);
+}
+
+
+// VIII. Presentation Functions and Properties
+
+/**
+ * Helper function to convert any value to a display string, considering IOMementoType.
+ */
+export function toDisplayString(value: any, type: TypeMemento): string {
+    if (value === null || value === undefined) return "null";
+
+    // Assuming type.typeName corresponds to IOMementoType values
+    switch (type.typeName) {
+        case IOMementoType.IoCharSeries:
+            // Assuming value is Series<string> where each string is a single char
+            return seriesCharToString(value as Series<string>);
+        // Add more custom formatting based on type if needed
+        // e.g. for Date, BigInt, etc.
+        case IOMementoType.IoLong:
+        case IOMementoType.IoBigInt:
+            return typeof value === 'bigint' ? value.toString() : String(value);
+        default:
+            return String(value);
+    }
+}
+
+/**
+ * Prints the first 'count' rows of the cursor to console.log.
+ * Default is 5 rows.
+ * Kotlin: fun <T> CoreTensorCursorWithMeta<T>.head(last: Int = 5)
+ */
+export function head<T>(ctcm: CoreTensorCursorWithMeta<T>, count: number = 5): void {
+    const numRowsToShow = Math.max(0, Math.min(count, cursorRows(ctcm.a)));
+    show(ctcm, { first: 0, last: numRowsToShow - 1 }); // Range last is inclusive
+}
+
+/**
+ * Prints 'n' random rows from the cursor to console.log.
+ */
+export function showRandom<T>(ctcm: CoreTensorCursorWithMeta<T>, n: number = 5): void {
+    const dataCursor = ctcm.a;
+    const numRows = cursorRows(dataCursor);
+    if (numRows === 0) {
+        console.log("Cursor is empty, cannot show random rows.");
+        return;
+    }
+    head(ctcm, 0); // Show header (column names)
+    for (let i = 0; i < n; i++) {
+        const randomIndex = Math.floor(Math.random() * numRows);
+        showValues(ctcm, { first: randomIndex, last: randomIndex });
+    }
+}
+
+/**
+ * Prints a summary of the cursor (rows, column names) and then calls showValues
+ * to print the data for a specified range.
+ */
+export function show<T>(ctcm: CoreTensorCursorWithMeta<T>, range?: IntRange): void {
+    const dataCursor = ctcm.a;
+    const metaCursor = meta(ctcm);
+    const names = cursorMetaNames(metaCursor);
+
+    console.log(`Cursor Rows: ${cursorRows(dataCursor)}, Columns: ${cursorCols(dataCursor)}`);
+    console.log("Columns:", names.join(", "));
+
+    const effectiveRange = range ?? { first: 0, last: cursorRows(dataCursor) - 1 };
+    showValues(ctcm, effectiveRange);
+}
+
+/**
+ * Prints the values of the cursor rows within the specified range to console.log.
+ */
+export function showValues<T>(ctcm: CoreTensorCursorWithMeta<T>, range: IntRange): void {
+    const dataCursor = ctcm.a;
+    const metaCursor = meta(ctcm);
+    const numRows = cursorRows(dataCursor);
+
+    if (range.first < 0 || range.last >= numRows || range.first > range.last) {
+        if (numRows === 0 && range.first === 0 && range.last === -1) { // Empty range for empty cursor
+             console.log("(Cursor is empty or range is invalid for empty cursor)");
+        } else {
+            console.error(`Cannot fully access range {first: ${range.first}, last: ${range.last}} for cursor with ${numRows} rows.`);
+        }
+        return;
+    }
+
+    try {
+        for (let i = range.first; i <= range.last; i++) {
+            const rowDataVec = getRow(dataCursor, i);
+            const rowValues = materialize(rowDataVec); // Get data for the row
+
+            const displayList: string[] = [];
+            for (let j = 0; j < rowValues.length; j++) {
+                const colMeta = getTensorValueRank1(metaCursor, j); // Get j-th ColumnMeta
+                const val = rowValues[j];
+                displayList.push(`${columnName(colMeta)}: ${toDisplayString(val, columnType(colMeta))}`);
+            }
+            console.log(`Row ${i}: { ${displayList.join(", ")} }`);
+        }
+    } catch (e: any) { // Catch any error during display
+        console.error(`An error occurred displaying range {first: ${range.first}, last: ${range.last}}: ${e.message}`);
+    }
+}
+
+/**
+ * Checks if all columns in the CoreTensorCursorWithMeta are of a numerical type.
+ * Based on a subset of IOMementoType considered numeric.
+ */
+export function isNumerical<T>(ctcm: CoreTensorCursorWithMeta<T>): boolean {
+    const metaCursor = meta(ctcm);
+    if (totalSize(metaCursor) === 0) return true; // Or false, depending on convention for empty
+
+    const numericTypes = new Set([
+        IOMementoType.IoByte, IOMementoType.IoShort, IOMementoType.IoInt,
+        IOMementoType.IoFloat, IOMementoType.IoDouble, IOMementoType.IoLong, IOMementoType.IoBigInt
+    ]);
+
+    for (const colMeta of materialize(metaCursor)) {
+        if (!numericTypes.has(columnType(colMeta).typeName as IOMementoType)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Checks if all columns in the CoreTensorCursorWithMeta have the same data type.
+ */
+export function isHomomorphic<T>(ctcm: CoreTensorCursorWithMeta<T>): boolean {
+    const metaCursor = meta(ctcm);
+    const numCols = totalSize(metaCursor);
+    if (numCols <= 1) return true;
+
+    const allMeta = materialize(metaCursor);
+    const firstColType = columnType(allMeta[0]).typeName;
+    for (let i = 1; i < numCols; i++) {
+        if (columnType(allMeta[i]).typeName !== firstColType) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// End of Part 4 of translation (Metadata and Presentation)


### PR DESCRIPTION
This commit introduces a TypeScript version of the `borg.trikeshed.core` library, located in `src/trikeshed/core.ts`.

The library provides data structures and operations for:
- Join, Twin, Series (including IterableSeries for materialization)
- Tensor (1D, 2D, nD) with accessor-based lazy evaluation
- Core Tensor operations: alphaConvert, linear/coords mapping, materialize, broadcasting (broadcastShapes, zip, combine)
- CoreTensorCursor for 2D data manipulation (row/col access, slicing)
- Metadata handling (ColumnMeta, TypeMemento, IOMemento) for cursors
- Column exclusion and selection by name/index
- Basic presentation functions (adapted to use console.log)

An initial suite of unit tests has been created in `src/trikeshed/core.test.ts`. These tests cover the core data structures and a selection of key operations.

IMPORTANT: Due to persistent issues with the execution environment, these unit tests could not be run to confirm their correctness or passing status. They are provided as a starting point for future verification when the testing environment is operational.